### PR TITLE
Degrade quality of conjured items twice as fast

### DIFF
--- a/csharp.xUnit/GildedRose/GildedRose.cs
+++ b/csharp.xUnit/GildedRose/GildedRose.cs
@@ -12,16 +12,18 @@ public class GildedRose
     }
 
     public void UpdateQuality()
-    {
+    {        
         for (var i = 0; i < Items.Count; i++)
         {
+            var daylyDegradation = Items[i].Name.StartsWith("Conjured") ? 2 : 1;
+
             if (Items[i].Name != "Aged Brie" && Items[i].Name != "Backstage passes to a TAFKAL80ETC concert")
             {
                 if (Items[i].Quality > 0)
                 {
                     if (Items[i].Name != "Sulfuras, Hand of Ragnaros")
                     {
-                        Items[i].Quality = Items[i].Quality - 1;
+                        Items[i].Quality = Items[i].Quality - daylyDegradation;
                     }
                 }
             }

--- a/csharp.xUnit/GildedRose/GildedRose.cs
+++ b/csharp.xUnit/GildedRose/GildedRose.cs
@@ -15,15 +15,13 @@ public class GildedRose
     {
         for (var i = 0; i < Items.Count; i++)
         {
-            var daylyDegradation = Items[i].Name.StartsWith("Conjured") ? 2 : 1;
-
             if (Items[i].Name != "Aged Brie" && Items[i].Name != "Backstage passes to a TAFKAL80ETC concert")
             {
                 if (Items[i].Quality > 0)
                 {
                     if (Items[i].Name != "Sulfuras, Hand of Ragnaros")
                     {
-                        Items[i].Quality = Items[i].Quality - daylyDegradation;
+                        Items[i].Quality -= Items[i].Name.StartsWith("Conjured") ? 2 : 1;
                     }
                 }
             }

--- a/csharp.xUnit/GildedRose/GildedRose.cs
+++ b/csharp.xUnit/GildedRose/GildedRose.cs
@@ -12,7 +12,7 @@ public class GildedRose
     }
 
     public void UpdateQuality()
-    {        
+    {
         for (var i = 0; i < Items.Count; i++)
         {
             var daylyDegradation = Items[i].Name.StartsWith("Conjured") ? 2 : 1;

--- a/csharp.xUnit/GildedRose/Program.cs
+++ b/csharp.xUnit/GildedRose/Program.cs
@@ -34,7 +34,7 @@ public class Program
                 SellIn = 5,
                 Quality = 49
             },
-            // this conjured item does not work properly yet
+
             new Item {Name = "Conjured Mana Cake", SellIn = 3, Quality = 6}
         };
 

--- a/csharp.xUnit/GildedRoseTests/ApprovalTest.ThirtyDays.verified.txt
+++ b/csharp.xUnit/GildedRoseTests/ApprovalTest.ThirtyDays.verified.txt
@@ -21,7 +21,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 14, 21
 Backstage passes to a TAFKAL80ETC concert, 9, 50
 Backstage passes to a TAFKAL80ETC concert, 4, 50
-Conjured Mana Cake, 2, 5
+Conjured Mana Cake, 2, 4
 
 -------- day 2 --------
 name, sellIn, quality
@@ -33,7 +33,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 13, 22
 Backstage passes to a TAFKAL80ETC concert, 8, 50
 Backstage passes to a TAFKAL80ETC concert, 3, 50
-Conjured Mana Cake, 1, 4
+Conjured Mana Cake, 1, 2
 
 -------- day 3 --------
 name, sellIn, quality
@@ -45,7 +45,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 12, 23
 Backstage passes to a TAFKAL80ETC concert, 7, 50
 Backstage passes to a TAFKAL80ETC concert, 2, 50
-Conjured Mana Cake, 0, 3
+Conjured Mana Cake, 0, 0
 
 -------- day 4 --------
 name, sellIn, quality
@@ -57,7 +57,7 @@ Sulfuras, Hand of Ragnaros, -1, 80
 Backstage passes to a TAFKAL80ETC concert, 11, 24
 Backstage passes to a TAFKAL80ETC concert, 6, 50
 Backstage passes to a TAFKAL80ETC concert, 1, 50
-Conjured Mana Cake, -1, 1
+Conjured Mana Cake, -1, 0
 
 -------- day 5 --------
 name, sellIn, quality

--- a/csharp.xUnit/GildedRoseTests/GildedRoseTest.cs
+++ b/csharp.xUnit/GildedRoseTests/GildedRoseTest.cs
@@ -1,17 +1,29 @@
 ﻿using Xunit;
-using System.Collections.Generic;
 using GildedRoseKata;
 
 namespace GildedRoseTests;
 
 public class GildedRoseTest
 {
-    [Fact]
-    public void foo()
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    public void ConjuredItems_DegradeFaster(int days)
     {
-        IList<Item> Items = new List<Item> { new Item { Name = "foo", SellIn = 0, Quality = 0 } };
-        GildedRose app = new GildedRose(Items);
-        app.UpdateQuality();
-        Assert.Equal("fixme", Items[0].Name);
+        // Arrange
+        var initialQuality = 30;
+        var normal = new Item { Name = "Normal item", SellIn = 10, Quality = initialQuality };
+        var conjured = new Item { Name = "Conjured item", SellIn = 10, Quality = initialQuality };
+        var app = new GildedRose([normal, conjured]);
+
+        // Act
+        for (int i = 0; i < days; i++)
+        {
+            app.UpdateQuality();
+        }
+
+        // Assert
+        Assert.Equal(initialQuality - days, normal.Quality);
+        Assert.Equal(initialQuality - 2 * days, conjured.Quality);
     }
 }


### PR DESCRIPTION
This PR adds the requested feature to support **Conjured items** in the inventory.

> Note: the name of conjured items must start with `Conjured` to make them degrade faster.

This PR does not include refactoring of code. 

I think we first need to evaluate why and how we need to refactor, given the [constraints defined here](https://github.com/vaerenberg/GildedRose-Refactoring-Kata/blob/main/GildedRoseRequirements.md#:~:text=do%20not%20alter%20the%20Item%20class%20or%20Items%20property%20as%20those%20belong%20to%20the%20goblin%20in%20the%20corner%20who%20will%20insta%2Drage%20and%20one%2Dshot%20you%20as%20he%20doesn%27t%20believe%20in%20shared%20code%20ownership).

To support our discussion on that constraint I created [a PR that respects the constraint here](https://github.com/vaerenberg/GildedRose-Refactoring-Kata/pull/2/)
